### PR TITLE
Revert "tasks/configure.yml: Validate systemd unit files"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -117,7 +117,6 @@
     owner: root
     group: root
     mode: 0644
-    validate: systemd-analyze verify %s
   register: unit
 
 - name: Enable and start


### PR DESCRIPTION
Reverts stuvusIT/pretix#2
Validating does not work, because Ansible does not use the correct file suffix in its temp files. That suffix would be needed for systemd to detect the unti type. See https://github.com/ansible/ansible/issues/19232