### PR TITLE
fix(permissions): Set correct permissions from the beginning

### DIFF
--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -20,8 +20,8 @@
   unarchive:
     src: "{{ global_cache_dir }}/confluence-{{ confluence_version }}.tar.gz"
     dest: /opt/atlassian-confluence-tmp
-    owner: root
-    group: root
+    owner: confluence
+    group: confluence
     mode: 0755
 
 # `mv` on the same filesystem is atomic. This makes sure that the destination only exists when the

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,7 @@
     group: confluence
     mode: 0770
   with_items:
+    - /var/lib/catalina/temp
     - /var/lib/confluence
     - /var/log/confluence
   notify: Restart confluence service
@@ -50,8 +51,8 @@
     src: server.xml.j2
     dest: /opt/atlassian-confluence-{{ confluence_version }}/conf/server.xml
     owner: root
-    group: root
-    mode: 0644
+    group: confluence
+    mode: 0640
   notify: Restart confluence service
 
 - name: Symlink logs directory
@@ -62,20 +63,6 @@
     force: true
     owner: confluence
     group: confluence
-  notify: Restart confluence service
-
-- name: Grant write privileges
-  file:
-    path: /opt/atlassian-confluence-{{ confluence_version }}/{{ item }}
-    owner: confluence
-    group: confluence
-    mode: 0775
-    recurse: yes
-  with_items:
-    - conf
-    - temp
-    - webapps
-    - work
   notify: Restart confluence service
 
 - name: Set home directory

--- a/templates/confluence.service.j2
+++ b/templates/confluence.service.j2
@@ -9,7 +9,7 @@ Type=simple
 SyslogIdentifier=confluence
 Environment="CATALINA_HOME=/opt/atlassian-confluence"
 Environment="CATALINA_BASE=/opt/atlassian-confluence"
-Environment="CATALINA_TMPDIR=/opt/atlassian-confluence/temp"
+Environment="CATALINA_TMPDIR=/var/lib/catalina/temp"
 Environment="JAVA_HOME={{ confluence_java_home }}"
 Environment="CLASSPATH=/opt/atlassian-confluence/bin/bootstrap.jar:/opt/atlassian-confluence/bin/tomcat-juli.jar"
 EnvironmentFile=-/etc/default/confluence


### PR DESCRIPTION
Instead of changing permissions.

Changing permissions lead to changes on every ansible run
as ansible changed permissions of files created by confluence